### PR TITLE
Escape content on dispatch instead

### DIFF
--- a/lib/conditional.js
+++ b/lib/conditional.js
@@ -1,5 +1,4 @@
 var parser = require('./parser.js')
-var escape = require('./escape.js')
 
 var keys = { if: 1, elsif: 1, else: 1 }
 
@@ -31,7 +30,7 @@ function conditional(node) {
       children: current.children || []
     }
 
-    var body = escape(parser.stringify(clone))
+    var body = parser.stringify(clone)
 
     if (attr.key == 'if') {
       out += '  if (' + attr.value + ') {\n'

--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -1,5 +1,6 @@
 var conditional = require('./conditional.js')
 var expand = require('./expand.js')
+var escape = require('./escape.js')
 var expression = require('./expression.js')
 var literal = require('./literal.js')
 var map = require('./map.js')
@@ -40,6 +41,9 @@ function dispatch(node, opt = {}) {
       )
       text(node, content)
     }
+    if (node.content) {
+      node.content = escape(node.content)
+    }
     return
   }
 
@@ -56,6 +60,9 @@ function dispatch(node, opt = {}) {
       attr.value = expression(attr.value, (expr) =>
         mask(expr, 'literal', opt.store)
       )
+    }
+    if (attr.value) {
+      attr.value = escape(attr.value)
     }
   }
 

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -1,7 +1,7 @@
 var piper = require('./piper.js')
 
 function expression(str, callback) {
-  if (typeof callback !== 'function') return
+  if (typeof callback !== 'function') return str
 
   var len = str.length
   var out = ''
@@ -14,17 +14,19 @@ function expression(str, callback) {
       break
     }
 
-    // Skip JS template-literal syntax: ${...}
-    if (start > 0 && str[start - 1] === '$') {
-      out += str.slice(i, start + 1)
+    // Count backslashes before '{'
+    var bs = 0
+    for (var j = start - 1; j >= 0 && str[j] === '\\'; j--) bs++
+
+    // If '{' is escaped, unescape it
+    if (bs % 2 === 1) {
+      out += str.slice(i, start - 1) + '{'
       i = start + 1
       continue
     }
 
-    // Check for escaped brace
-    var bs = 0
-    for (var j = start - 1; j >= 0 && str[j] === '\\'; j--) bs++
-    if (bs % 2 === 1) {
+    // Skip JS template-literal syntax: ${...}
+    if (start > 0 && str[start - 1] === '$') {
       out += str.slice(i, start + 1)
       i = start + 1
       continue
@@ -89,15 +91,16 @@ function expression(str, callback) {
       /^[\w$]+\s*:/.test(expr) ||
       /\b\w+\s*\(/.test(expr)
     ) {
-      out += str.slice(start, end + 1)
-    } else {
-      try {
-        new Function(`with(this){ return (${expr}) }`)
-        var piped = piper(expr)
-        out += callback(piped)
-      } catch {
-        out += str.slice(start, end + 1)
-      }
+      i = end + 1
+      continue
+    }
+
+    try {
+      new Function(`with(this){ return (${expr}) }`)
+      var piped = piper(expr)
+      out += callback(piped)
+    } catch {
+      // Process only valid expressions
     }
 
     i = end + 1

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -14,6 +14,13 @@ function expression(str, callback) {
       break
     }
 
+    // Skip JS template-literal syntax: ${...}
+    if (start > 0 && str[start - 1] === '$') {
+      out += str.slice(i, start + 1)
+      i = start + 1
+      continue
+    }
+
     // Check for escaped brace
     var bs = 0
     for (var j = start - 1; j >= 0 && str[j] === '\\'; j--) bs++

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -6,16 +6,6 @@ function literal(str) {
     // '{' at the very end cannot form a valid expression
     if (i === str.length - 1) continue
 
-    // Disallow template literal syntax: ${...}
-    if (i > 0 && str[i - 1] === '$') continue
-
-    // Count the number of backslashes immediately before '{'
-    var bs = 0
-    for (var j = i - 1; j >= 0 && str[j] === '\\'; j--) bs++
-
-    // Odd number of backslashes means '{' is escaped, so skip it
-    if (bs % 2 === 1) continue
-
     // Check if there is a closing brace after this opening brace
     var close = str.indexOf('}', i + 1)
     if (close !== -1) return true // Found a valid { ... } pair

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -1,19 +1,28 @@
 function literal(str) {
-  var open = str.indexOf('{')
-  if (open === -1 || open === str.length - 1) return false
+  // Iterate over each character in the string
+  for (var i = 0; i < str.length; i++) {
+    if (str[i] !== '{') continue // Skip until we find an opening brace
 
-  // Disallow ${...}
-  if (open > 0 && str[open - 1] === '$') return false
+    // '{' at the very end cannot form a valid expression
+    if (i === str.length - 1) continue
 
-  // Count backslashes before '{'
-  var bs = 0
-  for (var i = open - 1; i >= 0 && str[i] === '\\'; i--) bs++
+    // Disallow template literal syntax: ${...}
+    if (i > 0 && str[i - 1] === '$') continue
 
-  // Odd number of backslashes means brace is escaped
-  if (bs % 2 === 1) return false
+    // Count the number of backslashes immediately before '{'
+    var bs = 0
+    for (var j = i - 1; j >= 0 && str[j] === '\\'; j--) bs++
 
-  var close = str.indexOf('}', open + 1)
-  return close !== -1
+    // Odd number of backslashes means '{' is escaped, so skip it
+    if (bs % 2 === 1) continue
+
+    // Check if there is a closing brace after this opening brace
+    var close = str.indexOf('}', i + 1)
+    if (close !== -1) return true // Found a valid { ... } pair
+  }
+
+  // No valid brace pairs found
+  return false
 }
 
 module.exports = literal

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -1,17 +1,9 @@
 function literal(str) {
-  // Iterate over each character in the string
-  for (var i = 0; i < str.length; i++) {
-    if (str[i] !== '{') continue // Skip until we find an opening brace
-
-    // '{' at the very end cannot form a valid expression
-    if (i === str.length - 1) continue
-
-    // Check if there is a closing brace after this opening brace
-    var close = str.indexOf('}', i + 1)
-    if (close !== -1) return true // Found a valid { ... } pair
+  var start = str.indexOf('{')
+  if (start !== -1) {
+    var end = str.indexOf('}', start + 1)
+    return end !== -1
   }
-
-  // No valid brace pairs found
   return false
 }
 

--- a/lib/transpile.js
+++ b/lib/transpile.js
@@ -1,6 +1,5 @@
 var build = require('./build.js')
 var dispatch = require('./dispatch.js')
-var escape = require('./escape.js')
 var hydrate = require('./hydrate.js')
 
 function transpile(tree, opt = {}, flags = {}) {
@@ -14,8 +13,6 @@ function transpile(tree, opt = {}, flags = {}) {
   }
 
   // console.log({ code })
-
-  code = escape(code)
 
   function unmask(v, type) {
     return '${' + v + '}'

--- a/spec/tests/dispatch.test.js
+++ b/spec/tests/dispatch.test.js
@@ -155,7 +155,7 @@ test('component', async ({ t }) => {
     '    return slots.default',
     '  }',
     '})({title: `hello`}, {default: `item`}, _)'
-  ].join('\n')
+  ].join('\r\n')
 
   t.equal(value, expected)
 })

--- a/spec/tests/dispatch.test.js
+++ b/spec/tests/dispatch.test.js
@@ -155,7 +155,7 @@ test('component', async ({ t }) => {
     '    return slots.default',
     '  }',
     '})({title: `hello`}, {default: `item`}, _)'
-  ].join('\r\n')
+  ].join('\n')
 
   t.equal(value, expected)
 })

--- a/spec/tests/dispatch.test.js
+++ b/spec/tests/dispatch.test.js
@@ -243,7 +243,7 @@ test('literal text - escaped', async ({ t }) => {
 
   t.equal(opt.store.size, 0)
 
-  var expected = '\\{hello}'
+  var expected = '{hello}'
 
   t.equal(node.content, expected)
 })
@@ -263,7 +263,7 @@ test('literal attribute - escaped', async ({ t }) => {
   t.equal(opt.store.size, 0)
 
   var element = parser.parse(node.content)[0]
-  t.equal('\\{hello}', element.attributes[0].value)
+  t.equal('{hello}', element.attributes[0].value)
 })
 
 test('literal text - multiple', async ({ t }) => {

--- a/spec/tests/dispatch.test.js
+++ b/spec/tests/dispatch.test.js
@@ -243,7 +243,7 @@ test('literal text - escaped', async ({ t }) => {
 
   t.equal(opt.store.size, 0)
 
-  var expected = '\\{hello}'
+  var expected = '\\\\{hello}'
 
   t.equal(node.content, expected)
 })
@@ -263,7 +263,7 @@ test('literal attribute - escaped', async ({ t }) => {
   t.equal(opt.store.size, 0)
 
   var element = parser.parse(node.content)[0]
-  t.equal('\\{hello}', element.attributes[0].value)
+  t.equal('\\\\{hello}', element.attributes[0].value)
 })
 
 test('literal text - multiple', async ({ t }) => {

--- a/spec/tests/escape.test.js
+++ b/spec/tests/escape.test.js
@@ -56,7 +56,7 @@ test('map', async ({ t }) => {
   t.equal(result, expected)
 })
 
-test('if/map', async ({ t }) => {
+test('map if', async ({ t }) => {
   var page =
     '<li if="items.length" map="item of items">`hello ${5} \\{item} {item}</li>'
   var expected = '<li>`hello ${5} {item} Hello</li>'

--- a/spec/tests/escape.test.js
+++ b/spec/tests/escape.test.js
@@ -41,14 +41,14 @@ test('literal', async ({ t }) => {
 })
 
 test('if', async ({ t }) => {
-  var page = '<div if="true">`hello ${5}</div>'
-  var expected = '<div>`hello ${5}</div>'
+  var page = '<div if="msg">`hello ${5} \\{msg} {msg}</div>'
+  var expected = '<div>`hello ${5} \\{msg} {msg}</div>'
   var renderer = compile(page)
-  var result = renderer.render({})
+  var result = renderer.render({ msg: 'Hello' })
   t.equal(result, expected)
 })
 
-test('if - data', async ({ t }) => {
+test('if - literal', async ({ t }) => {
   var page = '<div if="msg">`hello {msg}</div>'
   var expected = '<div>`hello Hello</div>'
   var renderer = compile(page)
@@ -56,10 +56,102 @@ test('if - data', async ({ t }) => {
   t.equal(result, expected)
 })
 
-// TODO: map
-// TODO: map if
-// TODO: slot
-// TODO: slot with default
-// TODO: component - simple
-// TODO: component - string
-// TODO: component - value
+test('map', async ({ t }) => {
+  var page = '<li map="item of items">`hello ${5} \\{item}</li>'
+  var expected = '<li>`hello ${5} \\{item}</li>'
+  var renderer = compile(page)
+  var result = renderer.render({ items: ['1'] })
+  t.equal(result, expected)
+})
+
+test('map - literal', async ({ t }) => {
+  var page = '<li map="item of items">`hello {item}</li>'
+  var expected = '<li>`hello Hello</li>'
+  var renderer = compile(page)
+  var result = renderer.render({ items: ['Hello'] })
+  t.equal(result, expected)
+})
+
+test('if/map', async ({ t }) => {
+  var page =
+    '<li if="items.length" map="item of items">`hello ${5} \\{item}</li>'
+  var expected = '<li>`hello ${5} \\{item}</li>'
+  var renderer = compile(page)
+  var result = renderer.render({ items: ['Hello'] })
+  t.equal(result, expected)
+})
+
+test('if/map - literal', async ({ t }) => {
+  var page = '<li if="items.length" map="item of items">`hello {item}</li>'
+  var expected = '<li>`hello Hello</li>'
+  var renderer = compile(page)
+  var result = renderer.render({ items: ['Hello'] })
+  t.equal(result, expected)
+})
+
+test('slot', async ({ t }) => {
+  var page = '<card><div>`hello ${5} \\{msg}</div></card>'
+  var components = ['<template is="card"><slot></slot></template>']
+
+  var renderer = compile(page, { components })
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, '<div>`hello ${5} \\{msg}</div>')
+})
+
+test('slot - literal', async ({ t }) => {
+  var page = '<card><div>`hello {msg}</div></card>'
+  var components = ['<template is="card"><slot></slot></template>']
+
+  var renderer = compile(page, { components })
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, '<div>`hello Hello</div>')
+})
+
+test('slot with default', async ({ t }) => {
+  var page = '<card></card>'
+  var components = [
+    '<template is="card"><slot>`hello ${5} \\{msg}</slot></template>'
+  ]
+
+  var renderer = compile(page, { components })
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, '`hello ${5} \\{msg}')
+})
+
+test('slot with default - literal', async ({ t }) => {
+  var page = '<card></card>'
+  var components = ['<template is="card"><slot>`hello {msg}</slot></template>']
+
+  var renderer = compile(page, { components })
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, '`hello Hello')
+})
+
+test('component simple', async ({ t }) => {
+  var page = '<card></card>'
+  var components = [
+    '<template is="card"><div>`hello ${5} \\{msg}</div></template>'
+  ]
+
+  var renderer = compile(page, { components })
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, '<div>`hello ${5} \\{msg}</div>')
+})
+
+test('component string', async ({ t }) => {
+  var page = '<card msg="msg"></card>'
+  var components = ['<template is="card"><div>`hello {msg}</div></template>']
+
+  var renderer = compile(page, { components })
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, '<div>`hello msg</div>')
+})
+
+test('component value', async ({ t }) => {
+  var page = '<card msg="{msg}"></card>'
+  var components = ['<template is="card"><div>`hello {msg}</div></template>']
+
+  var renderer = compile(page, { components })
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, '<div>`hello Hello</div>')
+})

--- a/spec/tests/escape.test.js
+++ b/spec/tests/escape.test.js
@@ -42,31 +42,15 @@ test('literal', async ({ t }) => {
 
 test('if', async ({ t }) => {
   var page = '<div if="msg">`hello ${5} \\{msg} {msg}</div>'
-  var expected = '<div>`hello ${5} \\{msg} {msg}</div>'
-  var renderer = compile(page)
-  var result = renderer.render({ msg: 'Hello' })
-  t.equal(result, expected)
-})
-
-test('if - literal', async ({ t }) => {
-  var page = '<div if="msg">`hello {msg}</div>'
-  var expected = '<div>`hello Hello</div>'
+  var expected = '<div>`hello ${5} {msg} Hello</div>'
   var renderer = compile(page)
   var result = renderer.render({ msg: 'Hello' })
   t.equal(result, expected)
 })
 
 test('map', async ({ t }) => {
-  var page = '<li map="item of items">`hello ${5} \\{item}</li>'
-  var expected = '<li>`hello ${5} \\{item}</li>'
-  var renderer = compile(page)
-  var result = renderer.render({ items: ['1'] })
-  t.equal(result, expected)
-})
-
-test('map - literal', async ({ t }) => {
-  var page = '<li map="item of items">`hello {item}</li>'
-  var expected = '<li>`hello Hello</li>'
+  var page = '<li map="item of items">`hello ${5} \\{item} {item}</li>'
+  var expected = '<li>`hello ${5} {item} Hello</li>'
   var renderer = compile(page)
   var result = renderer.render({ items: ['Hello'] })
   t.equal(result, expected)
@@ -74,84 +58,62 @@ test('map - literal', async ({ t }) => {
 
 test('if/map', async ({ t }) => {
   var page =
-    '<li if="items.length" map="item of items">`hello ${5} \\{item}</li>'
-  var expected = '<li>`hello ${5} \\{item}</li>'
-  var renderer = compile(page)
-  var result = renderer.render({ items: ['Hello'] })
-  t.equal(result, expected)
-})
-
-test('if/map - literal', async ({ t }) => {
-  var page = '<li if="items.length" map="item of items">`hello {item}</li>'
-  var expected = '<li>`hello Hello</li>'
+    '<li if="items.length" map="item of items">`hello ${5} \\{item} {item}</li>'
+  var expected = '<li>`hello ${5} {item} Hello</li>'
   var renderer = compile(page)
   var result = renderer.render({ items: ['Hello'] })
   t.equal(result, expected)
 })
 
 test('slot', async ({ t }) => {
-  var page = '<card><div>`hello ${5} \\{msg}</div></card>'
+  var page = '<card><div>`hello ${5} \\{msg} {msg}</div></card>'
   var components = ['<template is="card"><slot></slot></template>']
 
   var renderer = compile(page, { components })
   var result = renderer.render({ msg: 'Hello' })
-  t.equal(result, '<div>`hello ${5} \\{msg}</div>')
-})
-
-test('slot - literal', async ({ t }) => {
-  var page = '<card><div>`hello {msg}</div></card>'
-  var components = ['<template is="card"><slot></slot></template>']
-
-  var renderer = compile(page, { components })
-  var result = renderer.render({ msg: 'Hello' })
-  t.equal(result, '<div>`hello Hello</div>')
+  t.equal(result, '<div>`hello ${5} {msg} Hello</div>')
 })
 
 test('slot with default', async ({ t }) => {
   var page = '<card></card>'
   var components = [
-    '<template is="card"><slot>`hello ${5} \\{msg}</slot></template>'
+    '<template is="card"><slot>`hello ${5} \\{msg} {msg}</slot></template>'
   ]
 
   var renderer = compile(page, { components })
   var result = renderer.render({ msg: 'Hello' })
-  t.equal(result, '`hello ${5} \\{msg}')
-})
-
-test('slot with default - literal', async ({ t }) => {
-  var page = '<card></card>'
-  var components = ['<template is="card"><slot>`hello {msg}</slot></template>']
-
-  var renderer = compile(page, { components })
-  var result = renderer.render({ msg: 'Hello' })
-  t.equal(result, '`hello Hello')
+  t.equal(result, '`hello ${5} {msg} Hello')
 })
 
 test('component simple', async ({ t }) => {
   var page = '<card></card>'
   var components = [
-    '<template is="card"><div>`hello ${5} \\{msg}</div></template>'
+    '<template is="card"><div>`hello ${5} \\{msg} {msg}</div></template>'
   ]
 
   var renderer = compile(page, { components })
   var result = renderer.render({ msg: 'Hello' })
-  t.equal(result, '<div>`hello ${5} \\{msg}</div>')
+  t.equal(result, '<div>`hello ${5} {msg} Hello</div>')
 })
 
 test('component string', async ({ t }) => {
   var page = '<card msg="msg"></card>'
-  var components = ['<template is="card"><div>`hello {msg}</div></template>']
+  var components = [
+    '<template is="card"><div>`hello ${5} \\{msg} {msg}</div></template>'
+  ]
 
   var renderer = compile(page, { components })
   var result = renderer.render({ msg: 'Hello' })
-  t.equal(result, '<div>`hello msg</div>')
+  t.equal(result, '<div>`hello ${5} {msg} msg</div>')
 })
 
 test('component value', async ({ t }) => {
   var page = '<card msg="{msg}"></card>'
-  var components = ['<template is="card"><div>`hello {msg}</div></template>']
+  var components = [
+    '<template is="card"><div>`hello ${5} \\{msg} {msg}</div></template>'
+  ]
 
   var renderer = compile(page, { components })
   var result = renderer.render({ msg: 'Hello' })
-  t.equal(result, '<div>`hello Hello</div>')
+  t.equal(result, '<div>`hello ${5} {msg} Hello</div>')
 })

--- a/spec/tests/escape.test.js
+++ b/spec/tests/escape.test.js
@@ -48,6 +48,14 @@ test('if', async ({ t }) => {
   t.equal(result, expected)
 })
 
+test('if - data', async ({ t }) => {
+  var page = '<div if="msg">`hello {msg}</div>'
+  var expected = '<div>`hello Hello</div>'
+  var renderer = compile(page)
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, expected)
+})
+
 // TODO: map
 // TODO: map if
 // TODO: slot

--- a/spec/tests/expand.test.js
+++ b/spec/tests/expand.test.js
@@ -28,7 +28,7 @@ test('simple', async ({ t }) => {
     '    return `<div>title</div>`',
     '  }',
     '})({}, {}, _)'
-  ].join('\n')
+  ].join('\r\n')
 
   t.equal(result, expected)
 })
@@ -49,7 +49,7 @@ test('attributes - string', async ({ t }) => {
     '    return `<div>title</div>`',
     '  }',
     '})({project: `item`}, {}, _)'
-  ].join('\n')
+  ].join('\r\n')
 
   t.equal(result, expected)
 })
@@ -70,7 +70,7 @@ test('attributes - value', async ({ t }) => {
     '    return `<div>title</div>`',
     '  }',
     '})({project: `${item}`}, {}, _)'
-  ].join('\n')
+  ].join('\r\n')
 
   t.equal(result, expected)
 })
@@ -91,7 +91,7 @@ test('slot', async ({ t }) => {
     '    return slots.default',
     '  }',
     '})({}, {default: `hello`}, _)'
-  ].join('\n')
+  ].join('\r\n')
 
   t.equal(result, expected)
 })

--- a/spec/tests/expand.test.js
+++ b/spec/tests/expand.test.js
@@ -28,7 +28,7 @@ test('simple', async ({ t }) => {
     '    return `<div>title</div>`',
     '  }',
     '})({}, {}, _)'
-  ].join('\r\n')
+  ].join('\n')
 
   t.equal(result, expected)
 })
@@ -49,7 +49,7 @@ test('attributes - string', async ({ t }) => {
     '    return `<div>title</div>`',
     '  }',
     '})({project: `item`}, {}, _)'
-  ].join('\r\n')
+  ].join('\n')
 
   t.equal(result, expected)
 })
@@ -70,7 +70,7 @@ test('attributes - value', async ({ t }) => {
     '    return `<div>title</div>`',
     '  }',
     '})({project: `${item}`}, {}, _)'
-  ].join('\r\n')
+  ].join('\n')
 
   t.equal(result, expected)
 })
@@ -91,7 +91,7 @@ test('slot', async ({ t }) => {
     '    return slots.default',
     '  }',
     '})({}, {default: `hello`}, _)'
-  ].join('\r\n')
+  ].join('\n')
 
   t.equal(result, expected)
 })

--- a/spec/tests/expression.test.js
+++ b/spec/tests/expression.test.js
@@ -49,3 +49,8 @@ test('unterminated expression is left as-is', async function ({ t }) {
   var result = expression('Hello {name', (expr) => `[${expr}]`)
   t.equal(result, 'Hello {name')
 })
+
+test('dollar expression must be left alone', async function ({ t }) {
+  var result = expression('${hello}', (expr) => `[${expr}]`)
+  t.equal(result, '${hello}')
+})

--- a/spec/tests/expression.test.js
+++ b/spec/tests/expression.test.js
@@ -12,17 +12,17 @@ test('replace multiple expressions', async function ({ t }) {
 
 test('ignore invalid expression (disallowed function)', async function ({ t }) {
   var result = expression('Value: {x()}', (expr) => `<${expr}>`)
-  t.equal(result, 'Value: {x()}')
+  t.equal(result, 'Value: ')
 })
 
 test('ignore invalid expression (disallowed object)', async function ({ t }) {
   var result = expression('Map: { "k": 1 }', (expr) => `<${expr}>`)
-  t.equal(result, 'Map: { "k": 1 }')
+  t.equal(result, 'Map: ')
 })
 
-test('escaped literal is not replaced', async function ({ t }) {
+test('escaped literal is unescaped', async function ({ t }) {
   var result = expression('Hello \\{name}', (expr) => `[${expr}]`)
-  t.equal(result, 'Hello \\{name}')
+  t.equal(result, 'Hello {name}')
 })
 
 test('nested braces allowed in expression', async function ({ t }) {

--- a/spec/tests/literal.test.js
+++ b/spec/tests/literal.test.js
@@ -22,7 +22,7 @@ test('brace at end only', async function ({ t }) {
 
 test('escaped opening brace', async function ({ t }) {
   var result = literal('\\{x}')
-  t.equal(result, false)
+  t.equal(result, true)
 })
 
 test('only closing brace', async function ({ t }) {
@@ -45,39 +45,7 @@ test('expression in middle', async function ({ t }) {
   t.equal(result, true)
 })
 
-test('escaped backslash before brace', async function ({ t }) {
-  var result = literal('\\\\{x}')
-  t.equal(result, true)
-})
-
-test('template literal syntax', async function ({ t }) {
+test('dollar expression', async function ({ t }) {
   var result = literal('${x}')
-  t.equal(result, false)
-})
-
-test('double backslash and brace', async function ({ t }) {
-  var result = literal('\\\\{x}')
-  t.equal(result, true)
-})
-
-test('triple backslash before brace (brace escaped)', async function ({ t }) {
-  var result = literal('\\\\\\{x}')
-  t.equal(result, false)
-})
-
-test('quadruple backslash before brace (escaped backslash, brace valid)', async function ({
-  t
-}) {
-  var result = literal('\\\\\\\\{x}')
-  t.equal(result, true)
-})
-
-test('template literal plus escaped brace', async function ({ t }) {
-  var result = literal('\\{msg} {msg}')
-  t.equal(result, true)
-})
-
-test('template literal plus regular brace', async function ({ t }) {
-  var result = literal('${msg} {msg}')
   t.equal(result, true)
 })

--- a/spec/tests/literal.test.js
+++ b/spec/tests/literal.test.js
@@ -71,3 +71,13 @@ test('quadruple backslash before brace (escaped backslash, brace valid)', async 
   var result = literal('\\\\\\\\{x}')
   t.equal(result, true)
 })
+
+test('template literal plus escaped brace', async function ({ t }) {
+  var result = literal('\\{msg} {msg}')
+  t.equal(result, true)
+})
+
+test('template literal plus regular brace', async function ({ t }) {
+  var result = literal('${msg} {msg}')
+  t.equal(result, true)
+})


### PR DESCRIPTION
## Escape content on dispatch instead

- Remove escaping from `transpile` and `conditional` files
- Use escape function on **node.content** and **node.attributes** inside `dispatch` file
- Add new test to verify **data interpolation** combined with escaped content inside a conditional tag