### PR TITLE
Avoid processing escaped and regular braces

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -1,7 +1,7 @@
 var piper = require('./piper.js')
 
 function expression(str, callback) {
-  if (typeof callback !== 'function') return
+  if (typeof callback !== 'function') return str
 
   var len = str.length
   var out = ''
@@ -14,17 +14,19 @@ function expression(str, callback) {
       break
     }
 
-    // Skip JS template-literal syntax: ${...}
-    if (start > 0 && str[start - 1] === '$') {
-      out += str.slice(i, start + 1)
+    // Count backslashes before '{'
+    var bs = 0
+    for (var j = start - 1; j >= 0 && str[j] === '\\'; j--) bs++
+
+    // If '{' is escaped, unescape it
+    if (bs % 2 === 1) {
+      out += str.slice(i, start - 1) + '{'
       i = start + 1
       continue
     }
 
-    // Check for escaped brace
-    var bs = 0
-    for (var j = start - 1; j >= 0 && str[j] === '\\'; j--) bs++
-    if (bs % 2 === 1) {
+    // Skip JS template-literal syntax: ${...}
+    if (start > 0 && str[start - 1] === '$') {
       out += str.slice(i, start + 1)
       i = start + 1
       continue
@@ -89,15 +91,16 @@ function expression(str, callback) {
       /^[\w$]+\s*:/.test(expr) ||
       /\b\w+\s*\(/.test(expr)
     ) {
-      out += str.slice(start, end + 1)
-    } else {
-      try {
-        new Function(`with(this){ return (${expr}) }`)
-        var piped = piper(expr)
-        out += callback(piped)
-      } catch {
-        out += str.slice(start, end + 1)
-      }
+      i = end + 1
+      continue
+    }
+
+    try {
+      new Function(`with(this){ return (${expr}) }`)
+      var piped = piper(expr)
+      out += callback(piped)
+    } catch {
+      // Process only valid expressions
     }
 
     i = end + 1

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -14,6 +14,13 @@ function expression(str, callback) {
       break
     }
 
+    // Skip JS template-literal syntax: ${...}
+    if (start > 0 && str[start - 1] === '$') {
+      out += str.slice(i, start + 1)
+      i = start + 1
+      continue
+    }
+
     // Check for escaped brace
     var bs = 0
     for (var j = start - 1; j >= 0 && str[j] === '\\'; j--) bs++

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -6,16 +6,6 @@ function literal(str) {
     // '{' at the very end cannot form a valid expression
     if (i === str.length - 1) continue
 
-    // Disallow template literal syntax: ${...}
-    if (i > 0 && str[i - 1] === '$') continue
-
-    // Count the number of backslashes immediately before '{'
-    var bs = 0
-    for (var j = i - 1; j >= 0 && str[j] === '\\'; j--) bs++
-
-    // Odd number of backslashes means '{' is escaped, so skip it
-    if (bs % 2 === 1) continue
-
     // Check if there is a closing brace after this opening brace
     var close = str.indexOf('}', i + 1)
     if (close !== -1) return true // Found a valid { ... } pair

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -1,19 +1,28 @@
 function literal(str) {
-  var open = str.indexOf('{')
-  if (open === -1 || open === str.length - 1) return false
+  // Iterate over each character in the string
+  for (var i = 0; i < str.length; i++) {
+    if (str[i] !== '{') continue // Skip until we find an opening brace
 
-  // Disallow ${...}
-  if (open > 0 && str[open - 1] === '$') return false
+    // '{' at the very end cannot form a valid expression
+    if (i === str.length - 1) continue
 
-  // Count backslashes before '{'
-  var bs = 0
-  for (var i = open - 1; i >= 0 && str[i] === '\\'; i--) bs++
+    // Disallow template literal syntax: ${...}
+    if (i > 0 && str[i - 1] === '$') continue
 
-  // Odd number of backslashes means brace is escaped
-  if (bs % 2 === 1) return false
+    // Count the number of backslashes immediately before '{'
+    var bs = 0
+    for (var j = i - 1; j >= 0 && str[j] === '\\'; j--) bs++
 
-  var close = str.indexOf('}', open + 1)
-  return close !== -1
+    // Odd number of backslashes means '{' is escaped, so skip it
+    if (bs % 2 === 1) continue
+
+    // Check if there is a closing brace after this opening brace
+    var close = str.indexOf('}', i + 1)
+    if (close !== -1) return true // Found a valid { ... } pair
+  }
+
+  // No valid brace pairs found
+  return false
 }
 
 module.exports = literal

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -1,17 +1,9 @@
 function literal(str) {
-  // Iterate over each character in the string
-  for (var i = 0; i < str.length; i++) {
-    if (str[i] !== '{') continue // Skip until we find an opening brace
-
-    // '{' at the very end cannot form a valid expression
-    if (i === str.length - 1) continue
-
-    // Check if there is a closing brace after this opening brace
-    var close = str.indexOf('}', i + 1)
-    if (close !== -1) return true // Found a valid { ... } pair
+  var start = str.indexOf('{')
+  if (start !== -1) {
+    var end = str.indexOf('}', start + 1)
+    return end !== -1
   }
-
-  // No valid brace pairs found
   return false
 }
 

--- a/spec/tests/dispatch.test.js
+++ b/spec/tests/dispatch.test.js
@@ -243,7 +243,7 @@ test('literal text - escaped', async ({ t }) => {
 
   t.equal(opt.store.size, 0)
 
-  var expected = '\\{hello}'
+  var expected = '{hello}'
 
   t.equal(node.content, expected)
 })
@@ -263,7 +263,7 @@ test('literal attribute - escaped', async ({ t }) => {
   t.equal(opt.store.size, 0)
 
   var element = parser.parse(node.content)[0]
-  t.equal('\\{hello}', element.attributes[0].value)
+  t.equal('{hello}', element.attributes[0].value)
 })
 
 test('literal text - multiple', async ({ t }) => {

--- a/spec/tests/expression.test.js
+++ b/spec/tests/expression.test.js
@@ -49,3 +49,8 @@ test('unterminated expression is left as-is', async function ({ t }) {
   var result = expression('Hello {name', (expr) => `[${expr}]`)
   t.equal(result, 'Hello {name')
 })
+
+test('dollar expression must be left alone', async function ({ t }) {
+  var result = expression('${hello}', (expr) => `[${expr}]`)
+  t.equal(result, '${hello}')
+})

--- a/spec/tests/expression.test.js
+++ b/spec/tests/expression.test.js
@@ -12,17 +12,17 @@ test('replace multiple expressions', async function ({ t }) {
 
 test('ignore invalid expression (disallowed function)', async function ({ t }) {
   var result = expression('Value: {x()}', (expr) => `<${expr}>`)
-  t.equal(result, 'Value: {x()}')
+  t.equal(result, 'Value: ')
 })
 
 test('ignore invalid expression (disallowed object)', async function ({ t }) {
   var result = expression('Map: { "k": 1 }', (expr) => `<${expr}>`)
-  t.equal(result, 'Map: { "k": 1 }')
+  t.equal(result, 'Map: ')
 })
 
-test('escaped literal is not replaced', async function ({ t }) {
+test('escaped literal is unescaped', async function ({ t }) {
   var result = expression('Hello \\{name}', (expr) => `[${expr}]`)
-  t.equal(result, 'Hello \\{name}')
+  t.equal(result, 'Hello {name}')
 })
 
 test('nested braces allowed in expression', async function ({ t }) {

--- a/spec/tests/literal.test.js
+++ b/spec/tests/literal.test.js
@@ -22,7 +22,7 @@ test('brace at end only', async function ({ t }) {
 
 test('escaped opening brace', async function ({ t }) {
   var result = literal('\\{x}')
-  t.equal(result, false)
+  t.equal(result, true)
 })
 
 test('only closing brace', async function ({ t }) {
@@ -45,39 +45,7 @@ test('expression in middle', async function ({ t }) {
   t.equal(result, true)
 })
 
-test('escaped backslash before brace', async function ({ t }) {
-  var result = literal('\\\\{x}')
-  t.equal(result, true)
-})
-
-test('template literal syntax', async function ({ t }) {
+test('dollar expression', async function ({ t }) {
   var result = literal('${x}')
-  t.equal(result, false)
-})
-
-test('double backslash and brace', async function ({ t }) {
-  var result = literal('\\\\{x}')
-  t.equal(result, true)
-})
-
-test('triple backslash before brace (brace escaped)', async function ({ t }) {
-  var result = literal('\\\\\\{x}')
-  t.equal(result, false)
-})
-
-test('quadruple backslash before brace (escaped backslash, brace valid)', async function ({
-  t
-}) {
-  var result = literal('\\\\\\\\{x}')
-  t.equal(result, true)
-})
-
-test('template literal plus escaped brace', async function ({ t }) {
-  var result = literal('\\{msg} {msg}')
-  t.equal(result, true)
-})
-
-test('template literal plus regular brace', async function ({ t }) {
-  var result = literal('${msg} {msg}')
   t.equal(result, true)
 })

--- a/spec/tests/literal.test.js
+++ b/spec/tests/literal.test.js
@@ -71,3 +71,13 @@ test('quadruple backslash before brace (escaped backslash, brace valid)', async 
   var result = literal('\\\\\\\\{x}')
   t.equal(result, true)
 })
+
+test('template literal plus escaped brace', async function ({ t }) {
+  var result = literal('\\{msg} {msg}')
+  t.equal(result, true)
+})
+
+test('template literal plus regular brace', async function ({ t }) {
+  var result = literal('${msg} {msg}')
+  t.equal(result, true)
+})


### PR DESCRIPTION
## Avoid processing escaped and regular braces

- Avoid processing escaped and regular braces on `literal.js` allowing literals at the same time
- Avoid processing regular braces on `expression.js`