### PR TITLE
Add escaping and literal process on comments

### DIFF
--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -34,6 +34,19 @@ function dispatch(node, opt = {}) {
     return text(node, key)
   }
 
+  if (node.type === 'comment') {
+    if (literal(node.content)) {
+      var content = expression(node.content, (expr) =>
+        mask(expr, 'literal', opt.store)
+      )
+      text(node, content)
+    }
+    if (node.content) {
+      node.content = `<!--${escape(node.content)}-->`
+    }
+    return
+  }
+
   if (node.type == 'text') {
     if (literal(node.content)) {
       var content = expression(node.content, (expr) =>

--- a/spec/tests/dispatch.test.js
+++ b/spec/tests/dispatch.test.js
@@ -231,6 +231,29 @@ test('literal attribute', async ({ t }) => {
   t.equal(key, element.attributes[0].value)
 })
 
+test('literal comment', async ({ t }) => {
+  var node = {
+    type: 'comment',
+    content: '{hello}'
+  }
+
+  var opt = { store: new Map() }
+
+  dispatch(node, opt)
+
+  t.equal(opt.store.size, 1)
+
+  var entry = opt.store.entries().next().value
+  var [key, value] = entry
+
+  t.equal(key, '__::MASK_literal_0_::__')
+  t.equal(node.content, `<!--${key}-->`)
+
+  var expected = 'hello'
+
+  t.equal(value, expected)
+})
+
 test('literal text - escaped', async ({ t }) => {
   var node = {
     type: 'text',
@@ -264,6 +287,23 @@ test('literal attribute - escaped', async ({ t }) => {
 
   var element = parser.parse(node.content)[0]
   t.equal('{hello}', element.attributes[0].value)
+})
+
+test('literal comment - escaped', async ({ t }) => {
+  var node = {
+    type: 'comment',
+    content: '\\{hello}'
+  }
+
+  var opt = { store: new Map() }
+
+  dispatch(node, opt)
+
+  t.equal(opt.store.size, 0)
+
+  var expected = '<!--{hello}-->'
+
+  t.equal(node.content, expected)
 })
 
 test('literal text - multiple', async ({ t }) => {

--- a/spec/tests/escape.test.js
+++ b/spec/tests/escape.test.js
@@ -117,3 +117,21 @@ test('component value', async ({ t }) => {
   var result = renderer.render({ msg: 'Hello' })
   t.equal(result, '<div>`hello ${5} {msg} Hello</div>')
 })
+
+test('escape on attributes', async ({ t }) => {
+  var page = '<div data-test="`hello ${5} \\{msg} {msg}"></div>'
+  var expected = '<div data-test="`hello ${5} {msg} Hello"></div>'
+
+  var renderer = compile(page)
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, expected)
+})
+
+test('escape on comments', async ({ t }) => {
+  var page = '<!-- `hello ${5} \\{msg} {msg} --> <h1>Hi</h1>'
+  var expected = '<!-- `hello ${5} {msg} Hello --> <h1>Hi</h1>'
+
+  var renderer = compile(page)
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, expected)
+})


### PR DESCRIPTION
## Add escaping and literal process on comments

- Change **dispatch.js** to process literals on comments as well
- Escape comment content and add `<!-- -->` syntax to it
- Add test cases on **dispatch.test** and **escape.test**