### PR TITLE
Change expression to replace single braces only

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -33,8 +33,12 @@ function expression(str, callback) {
       continue
     }
 
+    var braceCount = 1
+    if (str[start + 1] === '{') braceCount++
+    if (str[start + 2] === '{') braceCount++
+
     out += str.slice(i, start)
-    i = start + 1
+    i = start + braceCount
 
     var depth = 1
     var end = i
@@ -76,16 +80,20 @@ function expression(str, callback) {
       isUnquotedKey.test(expr) ||
       hasFunctionCall.test(expr)
     ) {
-      i = end + 1
+      i = end + braceCount
       continue
     }
 
     try {
       new Function(`with(this){ return (${expr}) }`)
-      out += callback(piper(expr))
+      var result = callback(piper(expr))
+
+      var wrapLeft = braceCount > 1 ? '{'.repeat(braceCount - 1) : ''
+      var wrapRight = braceCount > 1 ? '}'.repeat(braceCount - 1) : ''
+      out += wrapLeft + result + wrapRight
     } catch {}
 
-    i = end + 1
+    i = end + braceCount
   }
 
   return out

--- a/spec/tests/expression.test.js
+++ b/spec/tests/expression.test.js
@@ -54,3 +54,13 @@ test('dollar expression must be left alone', async function ({ t }) {
   var result = expression('${hello}', (expr) => `[${expr}]`)
   t.equal(result, '${hello}')
 })
+
+test('replace on double braces', async function ({ t }) {
+  var result = expression('{{hello}}', (expr) => `[${expr}]`)
+  t.equal(result, '{[hello]}')
+})
+
+test('replace on triple braces', async function ({ t }) {
+  var result = expression('{{{hello}}}', (expr) => `[${expr}]`)
+  t.equal(result, '{{[hello]}}')
+})

--- a/spec/tests/render.test.js
+++ b/spec/tests/render.test.js
@@ -147,3 +147,11 @@ test('map component props', async ({ t }) => {
 
   t.equal(result, '<ul><li><a>1</a></li><li><a>2</a></li></ul>')
 })
+
+test('double and triple braces', async ({ t }) => {
+  var page = '<div>{{msg}} {{{msg}}}</div>'
+  var expected = '<div>{Hello} {{Hello}}</div>'
+  var renderer = html.compile(page)
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, expected)
+})


### PR DESCRIPTION
## Change expression to replace single braces only

- When multiple braces on expression, replace only the inner ones
- Add tests on **expresion.test** and **render.test** to verify it