### PR TITLE
Escape expr with double slashes

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -21,7 +21,7 @@ function expression(str, callback) {
     var bs = 0
     for (var j = start - 1; j >= 0 && str[j] === '\\'; j--) bs++
 
-    if (bs & 1) {
+    if (bs & 1 || bs == 2) {
       out += str.slice(i, start - 1) + '{'
       i = start + 1
       continue

--- a/spec/tests/escape.test.js
+++ b/spec/tests/escape.test.js
@@ -135,3 +135,12 @@ test('escape on comments', async ({ t }) => {
   var result = renderer.render({ msg: 'Hello' })
   t.equal(result, expected)
 })
+
+test('double slash on literal', async ({ t }) => {
+  var page = '<div>\\\\{msg}</div>'
+  var expected = '<div>\\{msg}</div>'
+
+  var renderer = compile(page)
+  var result = renderer.render({ msg: 'Hello' })
+  t.equal(result, expected)
+})


### PR DESCRIPTION
## Escape expr with double slashes

- Escape double as well as single slashes on **expression.js**
- Add new test case for it