### PR TITLE
Avoid thrown errors on transpile, add tests

### DIFF
--- a/lib/transpile.js
+++ b/lib/transpile.js
@@ -17,7 +17,11 @@ function transpile(tree, opt = {}, flags = {}) {
   var args = flags.slot ? ['props', 'slots', '_'] : ['props', '_']
   var body = `with (props) { return \`${code}\` }`
 
-  var fn = new Function(...args, body)
+  try {
+    var fn = new Function(...args, body)
+  } catch (err) {
+    return () => ''
+  }
 
   return fn
 }

--- a/spec/tests/render.test.js
+++ b/spec/tests/render.test.js
@@ -119,6 +119,42 @@ test('component props', async ({ t }) => {
   t.equal(result, '<div>hello</div>')
 })
 
+test('component html props', async ({ t }) => {
+  var page = '<card item="<div>{greeting}</div>">></card>'
+  var components = ['<template is="card">{item}</template>']
+  var opt = { components }
+
+  var renderer = html.compile(page, opt)
+
+  var result = renderer.render({ greeting: 'hello' })
+
+  t.equal(result, '<div>hello</div>')
+})
+
+test('component template props', async ({ t }) => {
+  var page = '<card item="{`<div>${5}</div>`}"></card>'
+  var components = ['<template is="card">{item}</template>']
+  var opt = { components }
+
+  var renderer = html.compile(page, opt)
+
+  var result = renderer.render({ greeting: 'hello' })
+
+  t.equal(result, '<div>5</div>')
+})
+
+test('component function props', async ({ t }) => {
+  var page = '<card item="{(function(){ return \'hello\' }()}"></card>'
+  var components = ['<template is="card">{item}</template>']
+  var opt = { components }
+
+  var renderer = html.compile(page, opt)
+
+  var result = renderer.render({ greeting: 'hello' })
+
+  t.equal(result, '')
+})
+
 test('deep component props', async ({ t }) => {
   var page = '<card greeting="{greeting}"></card>'
   var components = [


### PR DESCRIPTION
## Avoid thrown errors on transpile, add tests

- Add try/catch to eval function on **transpile.js** to avoid thrown errors on render
- Add new tests, including a function on component props that enters the catch on **transpile.js**