### PR TITLE
Handle mask and expr on expand, add new tests

### DIFF
--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -18,9 +18,7 @@ function dispatch(node, opt = {}) {
 
   var component = opt.components && opt.components[node.tagName]
   if (component) {
-    var content = expand(node, component)
-    var key = mask(content, 'expand', opt.store)
-    return text(node, key)
+    return expand(node, opt)
   }
 
   if (node.type == 'comment') {

--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -6,7 +6,7 @@ var literal = require('./literal.js')
 var map = require('./map.js')
 var parser = require('./parser.js')
 var slot = require('./slot.js')
-var text = require('./text.js')
+var implode = require('./implode.js')
 var mask = require('./mask.js')
 
 function dispatch(node, opt = {}) {
@@ -28,7 +28,7 @@ function dispatch(node, opt = {}) {
       })
       content = escape(content)
       content = '<!--' + content + '-->'
-      text(node, content)
+      implode(node, content)
     }
     return
   }
@@ -39,14 +39,14 @@ function dispatch(node, opt = {}) {
         return mask(expr, 'literal', opt.store)
       })
       content = escape(content)
-      text(node, content)
+      implode(node, content)
     }
     return
   }
 
   if (!atts || !atts.length || node.type != 'element') {
     var content = parser.stringify(node)
-    return text(node, content)
+    return implode(node, content)
   }
 
   var hasMap = false
@@ -78,30 +78,30 @@ function dispatch(node, opt = {}) {
     var content = map(node)
     if (content.length) {
       var key = mask(content, 'map', opt.store)
-      return text(node, key)
+      return implode(node, key)
     }
-    return text(node, content)
+    return implode(node, content)
   }
 
   if (hasIf) {
     var content = conditional(node)
     if (content.length) {
       var key = mask(content, 'if', opt.store)
-      return text(node, key)
+      return implode(node, key)
     }
-    return text(node, content)
+    return implode(node, content)
   }
 
   if (hasElsif) {
-    return text(node, '')
+    return implode(node, '')
   }
 
   if (hasElse) {
-    return text(node, '')
+    return implode(node, '')
   }
 
   var content = parser.stringify(node)
-  return text(node, content)
+  return implode(node, content)
 }
 
 module.exports = dispatch

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -2,7 +2,7 @@ var parser = require('./parser.js')
 var expression = require('./expression.js')
 var escape = require('./escape.js')
 var mask = require('./mask.js')
-var text = require('./text.js')
+var implode = require('./implode.js')
 
 function expand(node, opt) {
   var component = opt.components[node.tagName]
@@ -52,7 +52,7 @@ function expand(node, opt) {
   var content = '(' + fn + ')(' + props + ', ' + slots + ', _)'
 
   var key = mask(content, 'expand', opt.store)
-  text(node, key)
+  implode(node, key)
 }
 
 module.exports = expand

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -1,7 +1,12 @@
 var parser = require('./parser.js')
 var expression = require('./expression.js')
+var escape = require('./escape.js')
+var mask = require('./mask.js')
+var text = require('./text.js')
 
-function expand(node, component) {
+function expand(node, opt) {
+  var component = opt.components[node.tagName]
+
   var atts = node.attributes || []
   var children = node.children || []
   var fn = component.fn ? component.fn.toString() : ''
@@ -17,6 +22,7 @@ function expand(node, component) {
       if (nowrap) {
         val = expression(val, (expr) => expr) || "''"
       } else {
+        val = escape(val)
         val = expression(val, (expr) => '${' + expr + '}')
         val = '`' + val + '`'
       }
@@ -29,10 +35,24 @@ function expand(node, component) {
   var slots = '{}'
   if (children.length > 0) {
     var slotContent = parser.stringify(children)
-    slots = '{default: `' + slotContent + '`}'
+
+    var nowrap =
+      slotContent[0] == '{' && slotContent[slotContent.length - 1] == '}'
+    if (nowrap) {
+      slotContent = expression(slotContent, (expr) => expr) || "''"
+    } else {
+      slotContent = escape(slotContent)
+      slotContent = expression(slotContent, (expr) => '${' + expr + '}')
+      slotContent = '`' + slotContent + '`'
+    }
+
+    slots = `{default: ${slotContent}}`
   }
 
-  return '(' + fn + ')(' + props + ', ' + slots + ', _)'
+  var content = '(' + fn + ')(' + props + ', ' + slots + ', _)'
+
+  var key = mask(content, 'expand', opt.store)
+  text(node, key)
 }
 
 module.exports = expand

--- a/lib/implode.js
+++ b/lib/implode.js
@@ -1,4 +1,4 @@
-function text(node, content = '') {
+function implode(node, content = '') {
   delete node.children
   delete node.attributes
   delete node.tagName
@@ -7,4 +7,4 @@ function text(node, content = '') {
   node.content = content
 }
 
-module.exports = text
+module.exports = implode

--- a/lib/slot.js
+++ b/lib/slot.js
@@ -1,6 +1,6 @@
 var parser = require('./parser.js')
 var mask = require('./mask.js')
-var text = require('./text.js')
+var implode = require('./implode.js')
 var escape = require('./escape.js')
 var expression = require('./expression.js')
 
@@ -16,7 +16,7 @@ function slot(node, opt) {
   }
 
   var key = mask(slotContent, 'slot', opt.store)
-  text(node, key)
+  implode(node, key)
 }
 
 module.exports = slot

--- a/spec/tests/expand.test.js
+++ b/spec/tests/expand.test.js
@@ -20,17 +20,27 @@ test('simple', async ({ t }) => {
     children: []
   }
 
-  var result = expand(node, { fn: plain })
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: plain } }
+  }
 
-  var expected = [
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
     '(function (props, slots) {',
     '  with (props) {',
     '    return `<div>title</div>`',
     '  }',
     '})({}, {}, _)'
   ].join('\n')
+  t.equal(value, expectedVal)
 
-  t.equal(result, expected)
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
 })
 
 test('attributes - string', async ({ t }) => {
@@ -41,9 +51,17 @@ test('attributes - string', async ({ t }) => {
     children: []
   }
 
-  var result = expand(node, { fn: plain })
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: plain } }
+  }
 
-  var expected = [
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
     '(function (props, slots) {',
     '  with (props) {',
     '    return `<div>title</div>`',
@@ -51,49 +69,168 @@ test('attributes - string', async ({ t }) => {
     '})({project: `item`}, {}, _)'
   ].join('\n')
 
-  t.equal(result, expected)
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('attributes - string backticks', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'card',
+    attributes: [{ key: 'project', value: '`item' }],
+    children: []
+  }
+
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: plain } }
+  }
+
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (props, slots) {',
+    '  with (props) {',
+    '    return `<div>title</div>`',
+    '  }',
+    '})({project: `\\`item`}, {}, _)'
+  ].join('\n')
+
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('attributes - string dollar', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'card',
+    attributes: [{ key: 'project', value: '${item}' }],
+    children: []
+  }
+
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: plain } }
+  }
+
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (props, slots) {',
+    '  with (props) {',
+    '    return `<div>title</div>`',
+    '  }',
+    '})({project: `\\${item}`}, {}, _)'
+  ].join('\n')
+
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('attributes - string backslashes', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'card',
+    attributes: [{ key: 'project', value: '\\{text}' }],
+    children: []
+  }
+
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: plain } }
+  }
+
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (props, slots) {',
+    '  with (props) {',
+    '    return `<div>title</div>`',
+    '  }',
+    '})({project: `\\\\{text}`}, {}, _)'
+  ].join('\n')
+
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
 })
 
 test('attributes - value', async ({ t }) => {
   var node = {
     type: 'element',
     tagName: 'card',
-    attributes: [{ key: 'project', value: '{item}' }],
+    attributes: [{ key: 'project', value: '{{item}}' }],
     children: []
   }
 
-  var result = expand(node, { fn: plain })
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: plain } }
+  }
 
-  var expected = [
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
     '(function (props, slots) {',
     '  with (props) {',
     '    return `<div>title</div>`',
     '  }',
     '})({project: item}, {}, _)'
   ].join('\n')
+  t.equal(value, expectedVal)
 
-  t.equal(result, expected)
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
 })
 
 test('attributes - value empty', async ({ t }) => {
   var node = {
     type: 'element',
     tagName: 'card',
-    attributes: [{ key: 'project', value: '{}' }],
+    attributes: [{ key: 'project', value: '{{}}' }],
     children: []
   }
 
-  var result = expand(node, { fn: plain })
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: plain } }
+  }
 
-  var expected = [
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
     '(function (props, slots) {',
     '  with (props) {',
     '    return `<div>title</div>`',
     '  }',
     "})({project: ''}, {}, _)"
   ].join('\n')
+  t.equal(value, expectedVal)
 
-  t.equal(result, expected)
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
 })
 
 test('slot', async ({ t }) => {
@@ -104,15 +241,180 @@ test('slot', async ({ t }) => {
     children: [{ type: 'text', content: 'hello' }]
   }
 
-  var result = expand(node, { fn: slot })
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: slot } }
+  }
 
-  var expected = [
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
     '(function (props, slots) {',
     '  with (props) {',
     '    return slots.default',
     '  }',
     '})({}, {default: `hello`}, _)'
   ].join('\n')
+  t.equal(value, expectedVal)
 
-  t.equal(result, expected)
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('slot - backticks', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'card',
+    attributes: [],
+    children: [{ type: 'text', content: '`hello' }]
+  }
+
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: slot } }
+  }
+
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (props, slots) {',
+    '  with (props) {',
+    '    return slots.default',
+    '  }',
+    '})({}, {default: `\\`hello`}, _)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('slot - dollar', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'card',
+    attributes: [],
+    children: [{ type: 'text', content: '${hello}' }]
+  }
+
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: slot } }
+  }
+
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (props, slots) {',
+    '  with (props) {',
+    '    return slots.default',
+    '  }',
+    '})({}, {default: `\\${hello}`}, _)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('slot - backslashes', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'card',
+    attributes: [],
+    children: [{ type: 'text', content: '\\{hello}' }]
+  }
+
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: slot } }
+  }
+
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (props, slots) {',
+    '  with (props) {',
+    '    return slots.default',
+    '  }',
+    '})({}, {default: `\\\\{hello}`}, _)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('slot - value', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'card',
+    attributes: [],
+    children: [{ type: 'text', content: '{{item}}' }]
+  }
+
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: slot } }
+  }
+
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (props, slots) {',
+    '  with (props) {',
+    '    return slots.default',
+    '  }',
+    '})({}, {default: item}, _)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('slot - empty value', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'card',
+    attributes: [],
+    children: [{ type: 'text', content: '{{}}' }]
+  }
+
+  var opt = {
+    store: new Map(),
+    components: { card: { fn: slot } }
+  }
+
+  expand(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (props, slots) {',
+    '  with (props) {',
+    '    return slots.default',
+    '  }',
+    "})({}, {default: ''}, _)"
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_expand_0_::__'
+  t.equal(content, expectedContent)
 })

--- a/spec/tests/implode.test.js
+++ b/spec/tests/implode.test.js
@@ -1,4 +1,4 @@
-var text = require('../../lib/text.js')
+var implode = require('../../lib/implode.js')
 
 test('element', async ({ t }) => {
   var node = {
@@ -8,7 +8,7 @@ test('element', async ({ t }) => {
     children: []
   }
 
-  text(node)
+  implode(node)
 
   t.equal(node.type, 'text')
   t.equal(node.tagName, null)


### PR DESCRIPTION
## Handle mask and expr on expand, add new tests

- Generate masks on **expand.js** instead
- Generate expressions on **expand.js** for props and slots defaults
- Escape on props and slots defaults when needed
- Add tests to cover escaping and literal values