### PR TITLE
Handle mask and expr on map, add new tests

### DIFF
--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -30,6 +30,13 @@ function dispatch(node, opt = {}) {
     return text(node, opt)
   }
 
+  if (atts && atts.length) {
+    var hasMap = atts.some((x) => x.key == 'map')
+    if (hasMap) {
+      return map(node, opt)
+    }
+  }
+
   if (!atts || !atts.length || node.type != 'element') {
     var content = parser.stringify(node)
     return implode(node, content)
@@ -58,15 +65,6 @@ function dispatch(node, opt = {}) {
     if (attr.value) {
       attr.value = escape(attr.value)
     }
-  }
-
-  if (hasMap) {
-    var content = map(node)
-    if (content.length) {
-      var key = mask(content, 'map', opt.store)
-      return implode(node, key)
-    }
-    return implode(node, content)
   }
 
   if (hasIf) {

--- a/lib/map.js
+++ b/lib/map.js
@@ -1,8 +1,13 @@
+var expression = require('./expression.js')
+var implode = require('./implode.js')
+var literal = require('./literal.js')
 var parser = require('./parser.js')
+var escape = require('./escape.js')
+var mask = require('./mask.js')
 
 var keys = { map: 1, if: 1, elsif: 1, else: 1 }
 
-function map(node) {
+function map(node, opt) {
   var atts = node.attributes || []
   var attr
   var ifAttr
@@ -36,6 +41,14 @@ function map(node) {
 
   var content = parser.stringify(clone)
 
+  if (literal(content)) {
+    content = expression(content, function (expr) {
+      return mask(expr, 'literal', opt.store)
+    })
+  }
+
+  content = escape(content)
+
   var inner = ifAttr
     ? [
         `    if (${ifAttr.value}) {`,
@@ -53,7 +66,11 @@ function map(node) {
     '})(' + list + ')'
   ].join('\n')
 
-  return code
+  if (code.length) {
+    code = mask(code, 'map', opt.store)
+  }
+
+  implode(node, code)
 }
 
 module.exports = map

--- a/spec/tests/map.test.js
+++ b/spec/tests/map.test.js
@@ -1,4 +1,3 @@
-var parser = require('../../lib/parser.js')
 var map = require('../../lib/map.js')
 
 test('map', async ({ t }) => {
@@ -9,17 +8,202 @@ test('map', async ({ t }) => {
     children: [{ type: 'text', content: 'item' }]
   }
 
-  var result = map(node)
+  var opt = { store: new Map() }
 
-  var expected = [
+  map(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
     '(function (projects) {',
     '  return projects.map(function(project) {',
     '    return `<li>item</li>`',
     `  }).join('')`,
     '})(projects)'
   ].join('\n')
+  t.equal(value, expectedVal)
 
-  t.equal(result, expected)
+  var expectedContent = '__::MASK_map_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('map - backticks', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'li',
+    attributes: [{ key: 'map', value: 'project of projects' }],
+    children: [{ type: 'text', content: '`item' }]
+  }
+
+  var opt = { store: new Map() }
+
+  map(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (projects) {',
+    '  return projects.map(function(project) {',
+    '    return `<li>\\`item</li>`',
+    `  }).join('')`,
+    '})(projects)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_map_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('map - dollar', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'li',
+    attributes: [{ key: 'map', value: 'project of projects' }],
+    children: [{ type: 'text', content: '${item}' }]
+  }
+
+  var opt = { store: new Map() }
+
+  map(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (projects) {',
+    '  return projects.map(function(project) {',
+    '    return `<li>\\${item}</li>`',
+    `  }).join('')`,
+    '})(projects)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_map_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('map - backslashes', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'li',
+    attributes: [{ key: 'map', value: 'project of projects' }],
+    children: [{ type: 'text', content: '\\{{item}}' }]
+  }
+
+  var opt = { store: new Map() }
+
+  map(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (projects) {',
+    '  return projects.map(function(project) {',
+    '    return `<li>{{item}}</li>`',
+    `  }).join('')`,
+    '})(projects)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_map_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('map - value', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'li',
+    attributes: [{ key: 'map', value: 'project of projects' }],
+    children: [{ type: 'text', content: '{{item}}' }]
+  }
+
+  var opt = { store: new Map() }
+
+  map(node, opt)
+
+  var maskLiteral = '__::MASK_literal_0_::__'
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (projects) {',
+    '  return projects.map(function(project) {',
+    `    return \`<li>${maskLiteral}</li>\``,
+    `  }).join('')`,
+    '})(projects)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_map_1_::__'
+  t.equal(content, expectedContent)
+
+  var value = opt.store.get(maskLiteral)
+  t.equal(value, 'item')
+})
+
+test('map - empty value', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'li',
+    attributes: [{ key: 'map', value: 'project of projects' }],
+    children: [{ type: 'text', content: '{{}}' }]
+  }
+
+  var opt = { store: new Map() }
+
+  map(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (projects) {',
+    '  return projects.map(function(project) {',
+    '    return `<li></li>`',
+    `  }).join('')`,
+    '})(projects)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_map_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('map - everything', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'li',
+    attributes: [{ key: 'map', value: 'project of projects' }],
+    children: [{ type: 'text', content: '`item ${item} \\{{item}} {{item}}' }]
+  }
+
+  var opt = { store: new Map() }
+
+  map(node, opt)
+
+  var maskLiteral = '__::MASK_literal_0_::__'
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (projects) {',
+    '  return projects.map(function(project) {',
+    '    return `<li>\\`item \\${item} {{item}} ' + maskLiteral + '</li>`',
+    `  }).join('')`,
+    '})(projects)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_map_1_::__'
+  t.equal(content, expectedContent)
+
+  var value = opt.store.get(maskLiteral)
+  t.equal(value, 'item')
 })
 
 test('map if', async ({ t }) => {
@@ -33,9 +217,14 @@ test('map if', async ({ t }) => {
     children: [{ type: 'text', content: 'item' }]
   }
 
-  var result = map(node)
+  var opt = { store: new Map() }
 
-  var expected = [
+  map(node, opt)
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
     '(function (projects) {',
     '  return projects.map(function(project) {',
     '    if (project.active) {',
@@ -45,6 +234,47 @@ test('map if', async ({ t }) => {
     "  }).join('')",
     '})(projects)'
   ].join('\n')
+  t.equal(value, expectedVal)
 
-  t.equal(result, expected)
+  var expectedContent = '__::MASK_map_0_::__'
+  t.equal(content, expectedContent)
+})
+
+test('map if - everything', async ({ t }) => {
+  var node = {
+    type: 'element',
+    tagName: 'li',
+    attributes: [
+      { key: 'map', value: 'project of projects' },
+      { key: 'if', value: 'project.active' }
+    ],
+    children: [{ type: 'text', content: '`item ${item} \\{{item}} {{item}}' }]
+  }
+
+  var opt = { store: new Map() }
+
+  map(node, opt)
+
+  var maskLiteral = '__::MASK_literal_0_::__'
+
+  var content = node.content
+  var value = opt.store.get(content)
+
+  var expectedVal = [
+    '(function (projects) {',
+    '  return projects.map(function(project) {',
+    '    if (project.active) {',
+    '      return `<li>\\`item \\${item} {{item}} ' + maskLiteral + '</li>`',
+    '    }',
+    "    return ''",
+    "  }).join('')",
+    '})(projects)'
+  ].join('\n')
+  t.equal(value, expectedVal)
+
+  var expectedContent = '__::MASK_map_1_::__'
+  t.equal(content, expectedContent)
+
+  var value = opt.store.get(maskLiteral)
+  t.equal(value, 'item')
 })


### PR DESCRIPTION
## Handle mask and expr on map, add new tests

- Add literal and map masks on **map.js** directly and escape content
- Add tests on **map.test.js** to verify escaping and literals