### PR TITLE
Avoid errors when no node attrs on chain

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -1,18 +1,17 @@
 var empty = require('./empty.js')
 
 function skip(node) {
-  var atts = node.attributes || []
   var next = node.nextElement || {}
-  var nextHasConditional = next.attributes?.some(
-    (x) => x.key == 'elsif' || x.key == 'else'
-  )
+  var atts = next.attributes || []
+  var nextHasConditional = atts.some((x) => x.key == 'elsif' || x.key == 'else')
   return !!nextHasConditional
 }
 
 function start(node) {
   var current = node
   while (current) {
-    if (current.attributes.some((x) => x.key == 'if')) {
+    var atts = current.attributes || []
+    if (atts.some((x) => x.key == 'if')) {
       return current
     }
     current = current.previousElement

--- a/spec/tests/chain.test.js
+++ b/spec/tests/chain.test.js
@@ -115,3 +115,14 @@ test('stomp', async ({ t }) => {
   t.equal(a.type, 'text')
   t.equal(a.content, '')
 })
+
+test('no attr', async ({ t }) => {
+  var h1 = {
+    type: 'text',
+    content: '__::MASK_map_0_::__'
+  }
+
+  chain.skip(h1)
+  chain.start(h1)
+  chain.stomp(h1)
+})

--- a/spec/tests/render.test.js
+++ b/spec/tests/render.test.js
@@ -113,6 +113,21 @@ test('nested if on else', async ({ t }) => {
   t.equal(result, '<div><span>world</span></div>')
 })
 
+test('if else map', async ({ t }) => {
+  var page = [
+    '<div if="products?.length > 0" map="p of products">',
+    '  <span>{{p}}</span>',
+    '</div>',
+    '<div else></div>'
+  ].join('')
+
+  var renderer = html.compile(page)
+  var data = { products: ['world'] }
+  var result = renderer.render(data)
+
+  t.equal(result, '<div>  <span>world</span></div>')
+})
+
 test('map', async ({ t }) => {
   var page = '<ul><li map="p of projects">{{p.name}}</li></ul>'
 


### PR DESCRIPTION
## Avoid errors when no node attrs on chain

- Use default [] on node attributes to avoid errors on nodes of type text