### PR TITLE
Avoid undefined errors on mapArg

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -60,7 +60,7 @@ function map(node, opt) {
 
   var code = [
     '(function (mapArg) {',
-    `  return mapArg.map(function(${iterators}) {`,
+    `  return (mapArg || []).map(function(${iterators}) {`,
     ...inner,
     `  }).join('')`,
     '})(' + list + ')'

--- a/spec/tests/map.test.js
+++ b/spec/tests/map.test.js
@@ -17,7 +17,7 @@ test('map', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     '    return `<li>item</li>`',
     `  }).join('')`,
     '})(projects)}'
@@ -45,7 +45,7 @@ test('map - backticks', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     '    return `<li>\\`item</li>`',
     `  }).join('')`,
     '})(projects)}'
@@ -73,7 +73,7 @@ test('map - dollar', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     '    return `<li>\\${item}</li>`',
     `  }).join('')`,
     '})(projects)}'
@@ -101,7 +101,7 @@ test('map - backslashes', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     '    return `<li>{{item}}</li>`',
     `  }).join('')`,
     '})(projects)}'
@@ -131,7 +131,7 @@ test('map - value', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     `    return \`<li>${maskLiteral}</li>\``,
     `  }).join('')`,
     '})(projects)}'
@@ -162,7 +162,7 @@ test('map - empty value', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     '    return `<li></li>`',
     `  }).join('')`,
     '})(projects)}'
@@ -192,7 +192,7 @@ test('map - everything', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     '    return `<li>\\`item \\${item} {{item}} ' + maskLiteral + '</li>`',
     `  }).join('')`,
     '})(projects)}'
@@ -226,7 +226,7 @@ test('map if', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     '    if (project.active) {',
     '      return `<li>item</li>`',
     '    }',
@@ -262,7 +262,7 @@ test('map if - everything', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     '    if (project.active) {',
     '      return `<li>\\`item \\${item} {{item}} ' + maskLiteral + '</li>`',
     '    }',
@@ -296,7 +296,7 @@ test('map object notation', async ({ t }) => {
 
   var expectedVal = [
     '${(function (mapArg) {',
-    '  return mapArg.map(function(project) {',
+    '  return (mapArg || []).map(function(project) {',
     '    return `<li>item</li>`',
     `  }).join('')`,
     '})(projects.item)}'

--- a/spec/tests/render.test.js
+++ b/spec/tests/render.test.js
@@ -61,6 +61,16 @@ test('if map', async ({ t }) => {
   t.equal(result, '<ul><li>1</li><li>2</li></ul>')
 })
 
+test('if map - empty', async ({ t }) => {
+  var page = '<ul><li if="ps?.length" map="p of ps">{{p}}</li></ul>'
+
+  var renderer = html.compile(page)
+  var data = { ps: null }
+  var result = renderer.render(data)
+
+  t.equal(result, '<ul></ul>')
+})
+
 test('if map - consecutive', async ({ t }) => {
   var page = [
     '<ul if="false"><li map="p of ps">{{p}}</li></ul>',


### PR DESCRIPTION
## Avoid undefined errors on mapArg

- Add default `[]` when mapping the mapArg variable
- Change tests on **map.test.js** to match new change
- Add test on **render.test.js** to cover null on mapArg